### PR TITLE
Improve permissions aa1 to implement 1

### DIFF
--- a/src/components/atoms/AICheckbox/index.jsx
+++ b/src/components/atoms/AICheckbox/index.jsx
@@ -1,0 +1,37 @@
+//#region > Imports
+//> React
+// Contains all the functionality necessary to define React components
+import React from "react";
+//> MDB
+// "Material Design for Bootstrap" is a great UI design framework
+import { MDBInput } from "mdbreact";
+//#endregion
+
+//#region > Components
+/** @class Custom input */
+class AIInput extends React.Component {
+  render() {
+    const { label, name, checked, className } = this.props;
+
+    return (
+      <MDBInput
+        label={label}
+        type="checkbox"
+        id={name}
+        containerClass={className}
+        checked={checked}
+        onChange={(e) => this.props.handleChange(e.target.checked)}
+      />
+    );
+  }
+}
+//#endregion
+
+//#region > Exports
+export default AIInput;
+//#endregion
+
+/**
+ * SPDX-License-Identifier: (EUPL-1.2)
+ * Copyright © 2020 Simon Prast
+ */

--- a/src/components/atoms/AICheckbox/index.jsx
+++ b/src/components/atoms/AICheckbox/index.jsx
@@ -8,8 +8,8 @@ import { MDBInput } from "mdbreact";
 //#endregion
 
 //#region > Components
-/** @class Custom input */
-class AIInput extends React.Component {
+/** @class Custom checkbox input */
+class AICheckbox extends React.Component {
   render() {
     const { label, name, checked, className } = this.props;
 
@@ -28,7 +28,7 @@ class AIInput extends React.Component {
 //#endregion
 
 //#region > Exports
-export default AIInput;
+export default AICheckbox;
 //#endregion
 
 /**

--- a/src/components/atoms/index.js
+++ b/src/components/atoms/index.js
@@ -5,11 +5,12 @@
 import ScrollToTop from "./ScrollToTop";
 import AIInput from "./AIInput";
 import AIToggle from "./AIToggle";
+import AICheckbox from "./AICheckbox";
 //#endregion
 
 //#region > Exports
 //> Atoms
-export { ScrollToTop, AIInput, AIToggle };
+export { ScrollToTop, AIInput, AIToggle, AICheckbox };
 //#endregion
 
 /**

--- a/src/components/organisms/sections/Permissions/index.jsx
+++ b/src/components/organisms/sections/Permissions/index.jsx
@@ -117,7 +117,10 @@ class Permissions extends React.Component {
 
     if (this.state.activeItem === 0) {
       const results = users.filter((user) => {
-        if (this.unifyString(user.full_name).includes(val)) {
+        if (
+          this.unifyString(user.full_name).includes(val) ||
+          this.unifyString(user.username).includes(val)
+        ) {
           return user;
         }
       });
@@ -219,6 +222,21 @@ class Permissions extends React.Component {
         </MDBNav>
         <MDBTabContent className="card" activeItem={this.state.activeItem}>
           <MDBTabPane tabId={0} role="tabpanel">
+            <div className="text-right mb-3">
+              <MDBBtn
+                color="green"
+                className="mr-0"
+                onClick={() =>
+                  this.setState({
+                    modal: true,
+                    selectedUser: { isActive: true },
+                    addUser: true,
+                  })
+                }
+              >
+                Add user
+              </MDBBtn>
+            </div>
             <MDBListGroup>
               {users &&
                 users.map((user, p) => {
@@ -234,7 +252,8 @@ class Permissions extends React.Component {
                       key={p}
                     >
                       <div>
-                        <p className="lead mb-1">{user.full_name}</p>
+                        <p className="lead mb-0">{user.full_name}</p>
+                        <p className="small mb-1 text-muted">{user.username}</p>
                         <p className="mb-0 text-muted">
                           {user.groups.map((group, g) => {
                             const selectedGroup = groups.filter(
@@ -306,7 +325,7 @@ class Permissions extends React.Component {
             <MDBModalBody>
               <div className="d-flex justify-content-between">
                 <p className="lead font-weight-bold">
-                  {!this.state.addConnector
+                  {!this.state.addUser
                     ? this.state.selectedUser.full_name
                     : "Add new user"}
                 </p>
@@ -320,15 +339,30 @@ class Permissions extends React.Component {
                   Cancel
                 </MDBBtn>
               </div>
-              <AIInput
-                title="Full name"
-                description="Enter the full name of the user"
-                name="full_name"
-                placeholder="Connector Name"
-                value={this.state.selectedUser.full_name}
-                handleChange={this.handleUserChange}
-                key="full_name"
-              />
+              <MDBRow>
+                <MDBCol lg="6">
+                  <AIInput
+                    title="Full name"
+                    description="Enter the full name of the user"
+                    name="full_name"
+                    placeholder="Full Name"
+                    value={this.state.selectedUser.full_name}
+                    handleChange={this.handleUserChange}
+                    key="full_name"
+                  />
+                </MDBCol>
+                <MDBCol lg="6">
+                  <AIInput
+                    title="Username"
+                    description="Enter the full name of the user"
+                    name="username"
+                    placeholder="Username"
+                    value={this.state.selectedUser.username}
+                    handleChange={this.handleUserChange}
+                    key="username"
+                  />
+                </MDBCol>
+              </MDBRow>
               <MDBRow>
                 <MDBCol lg="6">
                   <AIToggle
@@ -368,10 +402,12 @@ class Permissions extends React.Component {
                                   value={group.id}
                                   key={group.id}
                                   selected={
-                                    this.state.selectedUser.groups.includes(
-                                      group.id
-                                    )
-                                      ? true
+                                    this.state.selectedUser.groups
+                                      ? this.state.selectedUser.groups.includes(
+                                          group.id
+                                        )
+                                        ? true
+                                        : false
                                       : false
                                   }
                                 >
@@ -391,7 +427,7 @@ class Permissions extends React.Component {
               </MDBRow>
               <div className="d-flex justify-content-between mt-3">
                 <div>
-                  {!this.state.addConnector && (
+                  {!this.state.addUser && (
                     <MDBBtn
                       color="danger"
                       onClick={() => {
@@ -410,7 +446,7 @@ class Permissions extends React.Component {
                     color="success"
                     size="md"
                     onClick={() => {
-                      if (!this.state.addConnector) {
+                      if (!this.state.addUser) {
                         this.props.alterUser(
                           this.state.selectedUser.id,
                           this.state.selectedUser
@@ -422,7 +458,7 @@ class Permissions extends React.Component {
                     }}
                   >
                     <MDBIcon icon="check-circle" />
-                    {!this.state.addConnector ? "Save" : "Create"}
+                    {!this.state.addUser ? "Save" : "Create"}
                   </MDBBtn>
                 </div>
               </div>

--- a/src/components/organisms/sections/Permissions/index.jsx
+++ b/src/components/organisms/sections/Permissions/index.jsx
@@ -321,7 +321,7 @@ class Permissions extends React.Component {
                             );
 
                             return (
-                              <code className="text-muted">
+                              <code className="text-muted" key={g}>
                                 {selectedGroup[0].title}
                               </code>
                             );

--- a/src/components/organisms/sections/Permissions/index.jsx
+++ b/src/components/organisms/sections/Permissions/index.jsx
@@ -210,7 +210,7 @@ class Permissions extends React.Component {
         )
       : [];
 
-    // Readd updated item to change
+    // Read updated item to change
     allPermissions = [
       ...otherPermissions,
       {

--- a/src/components/organisms/sections/Permissions/index.jsx
+++ b/src/components/organisms/sections/Permissions/index.jsx
@@ -306,6 +306,7 @@ class Permissions extends React.Component {
                         this.setState({
                           modal: true,
                           selectedUser: user,
+                          type: "user",
                         })
                       }
                       key={p}

--- a/src/components/organisms/sections/Permissions/index.jsx
+++ b/src/components/organisms/sections/Permissions/index.jsx
@@ -189,20 +189,26 @@ class Permissions extends React.Component {
     // Get all permissions
     let allPermissions = this.state.selectedGroup.permissions;
     // Remove item to change from permissions
-    let otherPermissions = allPermissions.filter(
-      (item) =>
-        this.unifyString(item.title) !== this.unifyString(permission.title)
-    );
+    let otherPermissions = allPermissions
+      ? allPermissions.filter(
+          (item) =>
+            this.unifyString(item.title) !== this.unifyString(permission.title)
+        )
+      : [];
     // Get current permission
-    let currentPermission = this.state.selectedGroup.permissions.filter(
-      (item) =>
-        this.unifyString(item.title) === this.unifyString(permission.title)
-    );
+    let currentPermission = allPermissions
+      ? allPermissions.filter(
+          (item) =>
+            this.unifyString(item.title) === this.unifyString(permission.title)
+        )
+      : [];
 
     // Remove type to change from permission types
-    let otherTypes = currentPermission[0].types.filter(
-      (item) => this.unifyString(item.name) !== this.unifyString(type.name)
-    );
+    let otherTypes = currentPermission[0]
+      ? currentPermission[0].types.filter(
+          (item) => this.unifyString(item.name) !== this.unifyString(type.name)
+        )
+      : [];
 
     // Readd updated item to change
     allPermissions = [
@@ -586,12 +592,14 @@ class Permissions extends React.Component {
                         <small>{permission.title}</small>
                       </MDBCol>
                       {permission.types.map((type, t) => {
-                        const selectedGroupPermissionType = selectedGroupPermission[0]
-                          ? selectedGroupPermission[0].types.filter(
-                              (item) =>
-                                this.unifyString(item.name) ===
-                                this.unifyString(type.name)
-                            )
+                        const selectedGroupPermissionType = selectedGroupPermission
+                          ? selectedGroupPermission[0]
+                            ? selectedGroupPermission[0].types.filter(
+                                (item) =>
+                                  this.unifyString(item.name) ===
+                                  this.unifyString(type.name)
+                              )
+                            : []
                           : [];
 
                         return (
@@ -649,7 +657,7 @@ class Permissions extends React.Component {
                             this.state.selectedGroup
                           );
                         } else {
-                          this.props.addGroup(this.state.selectedGroup);
+                          this.props.createGroup(this.state.selectedGroup);
                         }
                         this.toggleModal();
                       }}

--- a/src/components/organisms/sections/Permissions/index.jsx
+++ b/src/components/organisms/sections/Permissions/index.jsx
@@ -49,6 +49,9 @@ import {
   addUser,
   removeUser,
   getGroupPermissions,
+  alterGroup,
+  createGroup,
+  removeGroup,
 } from "../../../../store/actions/permissionActions";
 //> Components
 import { AIInput, AIToggle, AICheckbox } from "../../../atoms";
@@ -159,6 +162,15 @@ class Permissions extends React.Component {
     this.setState({
       selectedUser: {
         ...this.state.selectedUser,
+        [name]: value,
+      },
+    });
+  };
+
+  handleGroupChange = (name, value) => {
+    this.setState({
+      selectedGroup: {
+        ...this.state.selectedGroup,
         [name]: value,
       },
     });
@@ -534,7 +546,7 @@ class Permissions extends React.Component {
                 <div className="d-flex justify-content-between">
                   <p className="lead font-weight-bold">
                     {!this.state.addGroup
-                      ? this.state.selectedGroup.full_name
+                      ? this.state.selectedGroup.title
                       : "Add new group"}
                   </p>
                   <MDBBtn
@@ -551,11 +563,11 @@ class Permissions extends React.Component {
                   <MDBCol lg="6">
                     <AIInput
                       description="Enter the name of the group"
-                      name="name"
+                      name="title"
                       placeholder="Group name"
-                      value={this.state.selectedGroup.name}
-                      handleChange={this.handleUserChange}
-                      key="name"
+                      value={this.state.selectedGroup.title}
+                      handleChange={this.handleGroupChange}
+                      key="title"
                     />
                   </MDBCol>
                 </MDBRow>
@@ -672,6 +684,9 @@ const mapDispatchToProps = (dispatch) => {
     alterUser: (id, user) => dispatch(alterUser(id, user)),
     addUser: (user) => dispatch(addUser(user)),
     removeUser: (id) => dispatch(removeUser(id)),
+    alterGroup: (id, group) => dispatch(alterGroup(id, group)),
+    createGroup: (group) => dispatch(createGroup(group)),
+    removeGroup: (id) => dispatch(removeGroup(id)),
   };
 };
 //#endregion

--- a/src/store/actions/permissionActions.js
+++ b/src/store/actions/permissionActions.js
@@ -7,6 +7,7 @@ export const getAllUsers = () => {
         /* Wagtail uid */
         id: "296f9448212b537473769a5ded79fc6a658d4a3b2bcbc2cd762ea817f125ec10",
         full_name: "Florian Schett",
+        username: "schettf",
         groups: [
           /* Admin */
           "418a6dcfe4fbf7c194efac9b37cc0395241dd2590049477dc47950069fd6cb0c",
@@ -25,6 +26,7 @@ export const getAllUsers = () => {
         /* Wagtail uid */
         id: "3ae093f08af3622a290e81a33fbe50e052f12c765253d84ac85155a8f70e075d",
         full_name: "Nico Kleber",
+        username: "klebern",
         groups: [
           /* Moderator */
           "41bc06a11bee0f62f9ce469ebe6659f4587f9b88cfad4f3bf5c3261e4d7e5d76",

--- a/src/store/actions/permissionActions.js
+++ b/src/store/actions/permissionActions.js
@@ -56,7 +56,7 @@ export const getAllUsers = () => {
           error: {
             code: 730,
             message: "Could not get users",
-            origin: "permissions",
+            origin: "user",
           },
         },
       });
@@ -86,7 +86,7 @@ export const addUser = (user) => {
           error: {
             code: 731,
             message: "Could not create user",
-            origin: "permissions",
+            origin: "user",
           },
         },
       });
@@ -133,11 +133,48 @@ export const addGroup = (group) => {
             error: {
               code: 732,
               message: "Could not create group",
-              origin: "permissions",
+              origin: "group",
             },
           },
         });
       }
+    }
+  };
+};
+
+export const getGroupPermissions = () => {
+  return (dispatch, getState, { getIntel }) => {
+    // Dummy data
+    const result = [
+      {
+        title: "Access something",
+        types: [
+          { name: "add", status: false },
+          { name: "change", status: false },
+          { name: "delete", status: false },
+        ],
+      },
+    ];
+
+    if (result) {
+      dispatch({
+        type: "GET_GROUP_PERMISSIONS_SUCCESS",
+        payload: {
+          data: result,
+        },
+      });
+    } else {
+      dispatch({
+        type: "GET_GROUP_PERMISSIONS_FAIL",
+        payload: {
+          data: false,
+          error: {
+            code: 733,
+            message: "Could not get group permissions",
+            origin: "group",
+          },
+        },
+      });
     }
   };
 };
@@ -150,10 +187,30 @@ export const getAllGroups = () => {
       {
         id: "418a6dcfe4fbf7c194efac9b37cc0395241dd2590049477dc47950069fd6cb0c",
         title: "Admin",
+        permissions: [
+          {
+            title: "Access something",
+            types: [
+              { name: "add", status: true },
+              { name: "change", status: true },
+              { name: "delete", status: false },
+            ],
+          },
+        ],
       },
       {
         id: "41bc06a11bee0f62f9ce469ebe6659f4587f9b88cfad4f3bf5c3261e4d7e5d76",
         title: "Moderator",
+        permissions: [
+          {
+            title: "Access something else",
+            types: [
+              { name: "add", status: false },
+              { name: "change", status: false },
+              { name: "delete", status: false },
+            ],
+          },
+        ],
       },
     ];
 
@@ -170,9 +227,9 @@ export const getAllGroups = () => {
         payload: {
           data: false,
           error: {
-            code: 733,
+            code: 734,
             message: "Could not get groups",
-            origin: "permissions",
+            origin: "group",
           },
         },
       });

--- a/src/store/actions/permissionActions.js
+++ b/src/store/actions/permissionActions.js
@@ -237,6 +237,30 @@ export const getAllGroups = () => {
   };
 };
 
+// Alters group
+export const alterGroup = (id, newGroup) => {
+  return (dispatch, getState, { getIntel }) => {
+    //@TODO: Alter user by id
+    console.log(id, newGroup);
+  };
+};
+
+// Create group
+export const createGroup = (id, newGroup) => {
+  return (dispatch, getState, { getIntel }) => {
+    //@TODO: Alter user by id
+    console.log(id, newGroup);
+  };
+};
+
+// Removes group
+export const removeGroup = (id) => {
+  return (dispatch, getState, { getIntel }) => {
+    //@TODO: Remove user by id
+    console.log(id);
+  };
+};
+
 /**
  * SPDX-License-Identifier: (EUPL-1.2)
  * Copyright © 2020 Simon Prast

--- a/src/store/reducers/permissionReducer.js
+++ b/src/store/reducers/permissionReducer.js
@@ -1,6 +1,7 @@
 // Have initial state when state is not ready to be passed
 const initState = {
   groups: [],
+  groupPermissions: [],
   users: [],
   error: null,
 };
@@ -59,6 +60,24 @@ const permissionReducer = (state = initState, action) => {
       return {
         ...state,
         users: [],
+        error: action.payload.error,
+      };
+    case "GET_GROUP_PERMISSIONS_SUCCESS":
+      return {
+        ...state,
+        groupPermissions: action.payload.data,
+        error: null,
+      };
+    case "GET_GROUP_PERMISSIONS_FAIL":
+      console.error(
+        action.payload.error.code,
+        action.payload.error.origin,
+        action.payload.error.message
+      );
+
+      return {
+        ...state,
+        groupPermissions: [],
         error: action.payload.error,
       };
     default:


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->

-   [x] Have you added an explanation of what your changes do and why you'd like them to be included?
-   [ ] Have you updated or added documentation for the change?
-   [x] Have you tested your changes with successful results?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Documentation (non-breaking change which adds documentation)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

**What is the current behavior? (link to any open issues here)**

- Currently it is not possible to edit groups, create groups.
- Currently it is not possible to set permissions for groups.

**What is the new behavior (if this is a feature change)?**

- It is now to edit and create groups.
- Permissions have been introduced and can be set when editing or creating a group.

**Known issues**:

- When creating a group, permissions that have not been checked are not being initialized. This leads to the permission type not being set as state and therefore not having a `false` value. This should not be a breaking, but will be fixed on a later date by @Aichnerc 
